### PR TITLE
Add basic configuration support

### DIFF
--- a/ghconfig.py
+++ b/ghconfig.py
@@ -69,7 +69,7 @@ def remove_branch_protection(organisation, repository, branch):
 
 def load_configuration(configuration_file):
     with open(configuration_file) as config_file:
-        configuration = yaml.load(config_file)
+        configuration = yaml.load_safe(config_file)
         return configuration
 
 

--- a/ghconfig.py
+++ b/ghconfig.py
@@ -96,6 +96,9 @@ def check_config(organisation, filter, configuration):
     for repository in repositories:
         if config.get('protected_branches'):
             for branch in config['protected_branches']:
+                print(
+                    'Protecting branch {0} on {1}/{2}'.format(
+                        branch, organisation, repository['name']))
                 set_branch_protection(
                     organisation,
                     repository['name'],

--- a/ghconfig.py
+++ b/ghconfig.py
@@ -1,6 +1,7 @@
 import click
 import requests
 import os
+import yaml
 
 
 # Get GitHub token from environment variable
@@ -24,9 +25,6 @@ def search_repositories(organisation, name):
                 response.links['next']['url'], headers=headers)
             repositories += response.json()
 
-    print('Total {0} repositories: {1}'.format(
-        organisation, len(repositories)))
-
     repositories_found = []
 
     for repo in repositories:
@@ -36,7 +34,7 @@ def search_repositories(organisation, name):
     return repositories_found
 
 
-def set_branch_protection(organisation, repository, branch):
+def set_branch_protection(organisation, repository, branch, enforce_admins):
     headers = {
         'Authorization': 'Token {0}'.format(GH_TOKEN),
         'Accept': 'application/vnd.github.loki-preview+json'
@@ -48,7 +46,7 @@ def set_branch_protection(organisation, repository, branch):
     payload = {
         "required_status_checks": None,
         "required_pull_request_reviews": None,
-        "enforce_admins": True,
+        "enforce_admins": enforce_admins,
         "restrictions": None
     }
 
@@ -69,20 +67,40 @@ def remove_branch_protection(organisation, repository, branch):
     return response.status_code
 
 
+def load_configuration(configuration_file):
+    with open(configuration_file) as config_file:
+        configuration = yaml.load(config_file)
+        return configuration
+
+
 @click.option(
     '--organisation', help='Name of the Organisation or GitHub user.',
     default='alphagov')
 @click.option(
-    '--filter', help='Specify a filter for repository names (example: paas-'
+    '--filter', help='Specify a filter for repository names (example: paas-',
     default='')
+@click.option(
+    '--configuration', help='Configuration file', default='ghconfig.yml')
 @click.command()
-def check_config(organisation, filter):
+def check_config(organisation, filter, configuration):
     print('Checking GitHub configuration...')
 
     # Filter repositories to work on using the specified organisation and
     # repository names filter
-    repos = search_repositories(organisation, filter)
+    repositories = search_repositories(organisation, filter)
 
+    # Load configuration from file
+    config = load_configuration(configuration)
+
+    # Apply the configuration to found braches
+    for repository in repositories:
+        if config.get('protected_branches'):
+            for branch in config['protected_branches']:
+                set_branch_protection(
+                    organisation,
+                    repository['name'],
+                    branch,
+                    config.get('enforce_admins'))
 
 if __name__ == '__main__':
     check_config()

--- a/ghconfig.yml
+++ b/ghconfig.yml
@@ -1,0 +1,3 @@
+protected_branches:
+  - master
+enforce_admins: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 click==6.7
 pytest==3.2.0
+PyYAML==3.12
 requests==2.18.2
 responses==0.6.0

--- a/test_ghconfig.py
+++ b/test_ghconfig.py
@@ -68,7 +68,8 @@ def test_set_branch_protection():
     response = set_branch_protection(
         'andreagrandi',
         'andrea-test',
-        'master'
+        'master',
+        True
     )
 
     assert response[0] == 200


### PR DESCRIPTION
With this PR I've added a very basic support to store the configuration in a YAML file. The only option that is possible configure at the moment is if we want to enforce the configuration for admins and the name of protected branches.