### PR TITLE
Add method to remove a collaborator from a repository

### DIFF
--- a/ghconfig.py
+++ b/ghconfig.py
@@ -69,6 +69,19 @@ def remove_branch_protection(organisation, repository, branch):
     return response.status_code
 
 
+def remove_collaborator(organisation, repository, username):
+    headers = {
+        'Authorization': 'Token {0}'.format(GH_TOKEN),
+        'Accept': 'application/vnd.github.loki-preview+json'
+    }
+
+    api_url = '{0}/repos/{1}/{2}/collaborators/{3}'.format(
+        API_BASE_URL, organisation, repository, username)
+
+    response = requests.delete(api_url, headers=headers)
+    return response.status_code
+
+
 @click.option(
     '--organisation', help='Name of the Organisation or GitHub user.',
     default='alphagov')

--- a/test_ghconfig.py
+++ b/test_ghconfig.py
@@ -1,6 +1,7 @@
 import responses
 from ghconfig import (
-    search_repositories, set_branch_protection, remove_branch_protection)
+    search_repositories, set_branch_protection, remove_branch_protection,
+    remove_collaborator)
 import json
 
 
@@ -88,6 +89,25 @@ def test_remove_branch_protection():
         'andreagrandi',
         'andrea-test',
         'master'
+    )
+
+    assert response == 204
+
+
+@responses.activate
+def test_remove_collaborator():
+    responses.add(
+        responses.DELETE, (
+            'https://api.github.com/'
+            'repos/andreagrandi/andrea-test/collaborators/user1'),
+        status=204,
+        content_type='application/json',
+    )
+
+    response = remove_collaborator(
+        'andreagrandi',
+        'andrea-test',
+        'user1'
     )
 
     assert response == 204


### PR DESCRIPTION
This PR adds a method to remove a collaboratore from a repository. The method will be called from the main script once we have decided how to interface with it. This feature covers one of the use cases where a team needs to remove a former employee from all the repositories.